### PR TITLE
Simple Regressor Error Catching

### DIFF
--- a/simple_learn/regressors/simple_regressor.py
+++ b/simple_learn/regressors/simple_regressor.py
@@ -130,7 +130,9 @@ class SimpleRegressor:
                     grid_clf.fit(train_x, train_y)
                 except BaseException as error:
                     self.failed_models.append(name)
-                    self.logger.warning(f"{name} failed due to, Error : {error} and another model was fitted.")
+                    self.logger.warning(
+                        f"{name} failed due to, Error : {error} and another model was fitted."
+                    )
                     continue
                 end = time.time()
                 if self.metrics.get(

--- a/simple_learn/regressors/simple_regressor.py
+++ b/simple_learn/regressors/simple_regressor.py
@@ -128,9 +128,9 @@ class SimpleRegressor:
                 start = time.time()
                 try:
                     grid_clf.fit(train_x, train_y)
-                except ValueError as value_error:
+                except BaseException as error:
                     self.failed_models.append(name)
-                    self.logger.warning(f"{name} failed, Error : {value_error}")
+                    self.logger.warning(f"{name} failed due to, Error : {error} and another model was fitted.")
                     continue
                 end = time.time()
                 if self.metrics.get(

--- a/simple_learn/regressors/simple_regressor.py
+++ b/simple_learn/regressors/simple_regressor.py
@@ -131,7 +131,7 @@ class SimpleRegressor:
                 except BaseException as error:
                     self.failed_models.append(name)
                     self.logger.warning(
-                        f"{name} failed due to, Error : {error} and another model was fitted."
+                        f"{name} failed due to, Error : {error}."
                     )
                     continue
                 end = time.time()


### PR DESCRIPTION
This is for #53. Added BaseException for the SimpleRegressor Class and the model fit doesn't fail now and instead another model is fitted, the user is also notifed as to the failure occuring.

```python
 try:
      grid_clf.fit(train_x, train_y)
except BaseException as error:
      self.failed_models.append(name)
      self.logger.warning(f"{name} failed, Error : {error}")
      continue
```

```
>>> from sklearn.datasets import load_boston
>>> from simple_learn.regressors import SimpleRegressor
>>> boston = load_boston() 
>>> true_x = boston.data   
>>> true_y = boston.target 
>>> clf = SimpleRegressor()
>>> clf.fit(true_x, true_y)
DecisionTreeRegressor failed due to, Error : 'poisson' and another model was fitted.
>>> clf
{
    "Type": "GradientBoostingRegressor",
    "Training Duration": "0.138031005859375s",   
    "GridSearch Duration": "43.97470307350159s", 
    "Parameters": {
        "criterion": "friedman_mse",
        "learning_rate": 0.1,
        "loss": "huber",
        "max_depth": 3,
        "max_features": "sqrt",
        "n_estimators": 100
    },
    "Metrics": {
        "Training Score": 4.561456594041284,     
        "Mean Absolute Error": 1.265174768627777,
        "Mean Square Error": 3.3016410463586072, 
        "R-Squared": 0.9608900923353472
    }
}
>>>
```